### PR TITLE
feat: add happy config to docker compose

### DIFF
--- a/packages/pg-indexer-reader/docker-compose.local.yml
+++ b/packages/pg-indexer-reader/docker-compose.local.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - indexer-network
     environment:
-      RPC_HTTP_URL: http://host.docker.internal:8545
+      RPC_HTTP_URL: https://rpc.testnet.happy.tech/http
       DEBUG: "mud:*"
       DATABASE_URL: postgres://user:password@postgres/postgres
     command: pnpm tsx bin/postgres-decoded-indexer
@@ -36,7 +36,7 @@ services:
     networks:
       - indexer-network
     environment:
-      RPC_HTTP_URL: http://host.docker.internal:8545
+      RPC_HTTP_URL: https://rpc.testnet.happy.tech/http
       DEBUG: "mud:*"
       DATABASE_URL: postgres://user:password@postgres/postgres
     ports:


### PR DESCRIPTION
Updated RPC endpoint in docker-compose.local.yml to use the testnet RPC instead of localhost.

Environment file config (to be set in the root of `pg-indexer-reader`: https://www.notion.so/happychain/Primodium-1c504b72a58580d7848cf2eef2ef57c9?pvs=4#1d104b72a585805daef9d3812e4a192b
